### PR TITLE
Potential fix for code scanning alert no. 3: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,5 +1,8 @@
 name: Build
 
+permissions:
+  contents: read
+
 on:
   push:
     branches:


### PR DESCRIPTION
Potential fix for [https://github.com/domainic/attributer/security/code-scanning/3](https://github.com/domainic/attributer/security/code-scanning/3)

To fix the issue, we will add a `permissions` block at the root of the workflow file. This block will define the minimal permissions required for the workflow to function correctly. Based on the provided workflow, the jobs primarily involve checking out the repository, setting up Ruby, running linting and tests, and packaging a gem. These tasks only require `contents: read` permission. We will apply this permission globally to all jobs in the workflow by adding the `permissions` block at the root level.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
